### PR TITLE
Spectator chat fix

### DIFF
--- a/SkyWarsReloadedPlugin/src/main/java/com/walrusone/skywars/listeners/SpectatorListener.java
+++ b/SkyWarsReloadedPlugin/src/main/java/com/walrusone/skywars/listeners/SpectatorListener.java
@@ -55,7 +55,7 @@ import com.walrusone.skywars.utilities.Messaging;
 
 public class SpectatorListener implements Listener {
 
-	@EventHandler(ignoreCancelled = true)
+	@EventHandler(ignoreCancelled = true, priority=EventPriority.LOW)
 	protected void onChatSend(AsyncPlayerChatEvent e) {
 		GamePlayer gPlayer = SkyWarsReloaded.getPC().getPlayer(e.getPlayer().getUniqueId());
 		if (gPlayer.isSpectating()) {


### PR DESCRIPTION
Chat is being cancelled before the event can run
